### PR TITLE
Add idea-driven product strategy landing pages

### DIFF
--- a/englishpurana/src/App.css
+++ b/englishpurana/src/App.css
@@ -1,32 +1,231 @@
 .App {
   text-align: center;
   width: 100%;
-  height:100%;
+  min-height: 100vh;
   color: #ff6600;
 }
 
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
+.app-shell {
+  background:
+    radial-gradient(circle at top, rgba(255, 222, 173, 0.32), transparent 30%),
+    linear-gradient(180deg, #5d1f00 0%, #7a2f00 28%, #9f4300 65%, #b14e00 100%);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+.app-navbar {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
 }
 
-.App-header {
-  background-color: #ff6600;
-  min-height: 100vh;
-  width: 100%;
-  height: 100%;
+.brand-lockup,
+.nav-link-button a {
+  font-weight: 700;
+}
+
+.landing-page,
+.strategy-page {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 2vw, 2rem) 4rem;
+}
+
+.hero-panel,
+.content-section {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+}
+
+.hero-panel {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 1.5rem;
+  align-items: stretch;
+}
+
+.hero-copy,
+.hero-highlight-card,
+.content-section,
+.idea-card,
+.franchise-card,
+.interactive-card,
+.timeline-card,
+.kpi-card,
+.principle-card,
+.stack-card,
+.audience-row {
+  border-radius: 24px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.15);
+}
+
+.hero-copy,
+.hero-highlight-card,
+.content-section {
+  background: rgba(255, 248, 240, 0.92);
+  color: #4a1e00;
+}
+
+.hero-copy,
+.hero-highlight-card {
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  text-align: left;
+}
+
+.hero-copy h1,
+.strategy-hero h1 {
+  font-size: clamp(2.2rem, 4vw, 4rem);
+  line-height: 1.05;
+  margin: 0.5rem 0 1rem;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow,
+.mini-label {
+  display: inline-block;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-weight: 700;
+}
+
+.eyebrow {
+  color: #a04800;
+  font-size: 0.8rem;
+}
+
+.mini-label {
+  color: #c45a00;
+  font-size: 0.72rem;
+  margin-bottom: 0.75rem;
+}
+
+.hero-highlight-card ul,
+.timeline-card ul,
+.interactive-card ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  line-height: 1.7;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.content-section {
+  padding: 2rem;
+  text-align: left;
+}
+
+.alt-surface {
+  background: rgba(255, 240, 226, 0.96);
+}
+
+.section-heading {
+  margin-bottom: 1.5rem;
+}
+
+.section-heading h2 {
+  color: #552200;
+  margin: 0.4rem 0;
+}
+
+.goal-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.goal-tab {
+  border: 1px solid rgba(160, 72, 0, 0.22);
+  background: #fff7f1;
+  color: #552200;
+  border-radius: 18px;
+  padding: 1rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.goal-tab.active {
+  background: linear-gradient(135deg, #ffcf9b, #fff2e2);
+  border-color: rgba(160, 72, 0, 0.5);
+}
+
+.idea-card,
+.franchise-card,
+.interactive-card,
+.timeline-card,
+.kpi-card,
+.principle-card,
+.stack-card,
+.audience-row {
+  background: #fffdfb;
+  color: #552200;
+  padding: 1.25rem;
+  height: 100%;
+}
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.idea-pill {
+  background: #fff0e1;
+  color: #8e3c00;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.82rem;
+}
+
+.franchise-grid,
+.interactive-grid,
+.timeline-grid,
+.kpi-grid,
+.principles-list,
+.stack-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.franchise-grid,
+.kpi-grid,
+.stack-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.interactive-grid,
+.timeline-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.principles-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.metric-line,
+.audience-meta {
+  color: #8e3c00;
+}
+
+.audience-table {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.audience-row {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 1rem;
+  align-items: start;
 }
 
 .container {
@@ -42,14 +241,12 @@
   color: white;
 }
 
-/* Clear floats after the columns */
 .row:after {
-  content: "";
+  content: '';
   display: table;
   clear: both;
 }
 
-/* Create three unequal columns that floats next to each other */
 .column {
   padding: 10px;
 }
@@ -68,12 +265,61 @@
 
 .h4 {
   font-size: calc(200px + 2vmin);
-  textDecorationLine: 'underline';
+  text-decoration-line: underline;
 }
 
-.filldiv{
-  position:absolute;
-  bottom:20px;
+.filldiv {
+  position: absolute;
+  bottom: 20px;
+}
+
+.App-logo {
+  height: 40vmin;
+  pointer-events: none;
+}
+
+.App-header {
+  background-color: #ff6600;
+  min-height: 100vh;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .App-logo {
+    animation: App-logo-spin infinite 20s linear;
+  }
+}
+
+@media (max-width: 900px) {
+  .hero-panel,
+  .goal-tabs,
+  .franchise-grid,
+  .interactive-grid,
+  .timeline-grid,
+  .kpi-grid,
+  .principles-list,
+  .stack-grid,
+  .audience-row {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-page,
+  .strategy-page {
+    padding-inline: 1rem;
+  }
+
+  .content-section,
+  .hero-copy,
+  .hero-highlight-card {
+    padding: 1.25rem;
+  }
 }
 
 @keyframes App-logo-spin {

--- a/englishpurana/src/App.js
+++ b/englishpurana/src/App.js
@@ -1,21 +1,16 @@
-import Login from "./components/login";
-import Button from "react-bootstrap/Button";
-// import Text from 'react-text';
-import Main from "./components/main.js"
+import Main from './components/main';
 import './App.css';
-import { Provider } from "react-redux";
-import store from "./redux/store";
+import { Provider } from 'react-redux';
+import store from './redux/store';
 
 function App() {
-  console.log(store.getState())
   return (
-      <Provider store={store}>
-    <div className="App">
-      <Main />
-    </div>
-      </Provider>
+    <Provider store={store}>
+      <div className="App">
+        <Main />
+      </div>
+    </Provider>
   );
 }
-
 
 export default App;

--- a/englishpurana/src/App.test.js
+++ b/englishpurana/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the strategy-led Simple Puranas homepage', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/Simple Puranas can become more than a reading archive/i)).toBeInTheDocument();
+  expect(screen.getByText(/Five repeatable show formats/i)).toBeInTheDocument();
+  expect(screen.getByText(/90-day execution plan/i)).toBeInTheDocument();
 });

--- a/englishpurana/src/components/about.js
+++ b/englishpurana/src/components/about.js
@@ -1,84 +1,159 @@
-
-import Button from "react-bootstrap/Button";
-// import Text from 'react-text';
-import logo from '../logo.png';
-import Main from "./main.js"
-import { useHistory } from "react-router-dom";
+import Button from 'react-bootstrap/Button';
+import Navbar from 'react-bootstrap/Navbar';
+import { useHistory } from 'react-router-dom';
 import '../App.css';
-import Navbar from "react-bootstrap/Navbar";
+import logo from '../logo.png';
+import {
+  audienceSegments,
+  ideaPrinciples,
+  interactiveProducts,
+  rolloutPlan,
+} from '../content_deliveryIdeas';
 
 function About() {
   const history = useHistory();
 
-  const goLogin = () => {
-    history.push('/');
-  }
   return (
-    <div className="App">
-    <Navbar bg="warning" variant="light">
-    <Navbar.Brand href="/" >
-    <img
-      alt=""
-      src={logo}
-      width="35"
-      height="35"
-      className="d-inline-block align-top"
-    />{' '}
-      Simple Puranas
-    </Navbar.Brand>
-    <Navbar.Toggle />
-  <Navbar.Collapse className="justify-content-end">
-  <Navbar.Brand type="button" className="btn btn-link" style={{color:"white"}}>
-  <a href="about" style={{color:"Brown"}}>About</a>
-  </Navbar.Brand>
-  <Navbar.Text>
-&nbsp;&nbsp;
-  </Navbar.Text>
-    <Navbar.Text>
-    <Button variant="outline-light" href="/login">Signin</Button>
-    </Navbar.Text>
-  </Navbar.Collapse>
-  </Navbar>
-    <header className="App-header" style={{padding: "5px 50px 10px 50px"}}>
-    <br/>
-      <p className="mb-0 h1" style={{textDecoration:"underline", color:"yellow"}}>Simple Puranas</p>
-      <br/>
-      <p style={{textDecoration:"underline", color:"yellow"}}>Goal of the Simple Puranas</p>
-      <p>The ancient puranas contain stories written as verses in the times of sages</p>
-      <p>These stories were passed down from generations through scriptures and plays</p>
-      <p>We are slowly losing touch of these ancient stories which have much to teach us in current times as they were available in touch to translate sanskrit and hard to read books, scriptures or pdfs.</p>
-      <p>Simple puranas was designed as a tool to help interested readers of all age groups to easily access the content of these documents.</p>
-      <p>We aim to utilize modern development tools to provide this content in an manner which is easily assimilable and fun to peruse</p>
-      <br/>
-      <p style={{textDecoration:"underline", color:"yellow"}}>Source of simple puranas</p>
-      <p>The source of the content for simple puranas comes from a pdf which was one of the earliest attempts to digitise the stories in the puranas</p>
-      <p>The dharmic scriptures team translated and compiled the content of these stories in 2002</p>
-      <p>Puranas are so old that an author is not known, so are the vedas and the upanishads</p>
-      <p>Hindu scriptures have been passed down through generations without ownership of content</p>
-      <p>Simple puranas is an effort to carry forward this legacy so that future generations can benefit from these stories</p>
-      <br/>
-      <p style={{textDecoration:"underline", color:"yellow"}}>Karma point system</p>
-      <p>The Karma system is hindu tradition which say good and bad deeds are tracked by the creator of the universe and rewarded as such</p>
-      <p>We created a simple point system to keep the readers motivate, the score of reading a page is the sum of the points scored for all the pages read before it in the current session</p>
-      <p>The puranas are dense, and we encourage the user to read as many puranas, chapters and sections, as they can in a single session</p>
-      <p>Quizzes will be made available and online competitions will be held to boost the karma points of the dharmic readers</p>
-      <p>It is very easy to score good karma and very hard to incur bad karma as long as the teachings of the puranas are kep close to heart</p>
-      <br/>
-      <p style={{textDecoration:"underline", color:"yellow"}}>How to use</p>
-      <p>Login with your Gmail id and we will create your profile</p>
-      <p>Check the index for the purana you want to read</p>
-      <p>Start from the top and read to the bottom of each page</p>
-      <p>Meditate on the beauty of any image you find extremely pleasing, this will help you build a love for god and calm your heart, mind and soul.</p>
-      <p>Reflect on the meaning of the section and try to understand any shloka or complicated word</p>
-      <p>Click next to go the next section, keep conscious track of which section you are at, so that you may revisit it later</p>
-      <p>Share any section you particularly like on social media through the various buttons made available</p>
-      <br/>
-      <p style={{textDecoration:"underline", color:"yellow"}}>Jai Shree Krishna, Jai Shree Ram, Om Namah Shivay!</p>
-      <input type="button" className="btn btn-primary" value="Home" onClick={goLogin}></input>
-    </header>
+    <div className="App app-shell">
+      <Navbar bg="warning" variant="light" className="app-navbar">
+        <Navbar.Brand href="/" className="brand-lockup">
+          <img
+            alt="Simple Puranas logo"
+            src={logo}
+            width="35"
+            height="35"
+            className="d-inline-block align-top"
+          />{' '}
+          Simple Puranas
+        </Navbar.Brand>
+        <Navbar.Toggle />
+        <Navbar.Collapse className="justify-content-end">
+          <Navbar.Brand className="btn btn-link nav-link-button">
+            <a href="about" style={{ color: 'brown' }}>
+              Roadmap
+            </a>
+          </Navbar.Brand>
+          <Navbar.Text>
+            <Button variant="outline-light" href="/login">
+              Sign in
+            </Button>
+          </Navbar.Text>
+        </Navbar.Collapse>
+      </Navbar>
+
+      <main className="strategy-page">
+        <section className="content-section strategy-hero">
+          <span className="eyebrow">Product roadmap</span>
+          <h1>How to evolve Simple Puranas from archive into ecosystem.</h1>
+          <p className="hero-lead">
+            The strongest opportunity in this repository is not just preserving text. It is packaging Purana
+            wisdom for different ages, contexts, and rituals without losing reverence or clarity.
+          </p>
+          <div className="hero-actions">
+            <Button variant="primary" onClick={() => history.push('/')}>
+              Back to overview
+            </Button>
+            <Button variant="outline-light" onClick={() => history.push('/login')}>
+              Open the reader
+            </Button>
+          </div>
+        </section>
+
+        <section className="content-section alt-surface">
+          <div className="section-heading">
+            <span className="eyebrow">Operating principles</span>
+            <h2>Guidelines for building the next version of the product.</h2>
+          </div>
+          <div className="principles-list">
+            {ideaPrinciples.map((principle) => (
+              <div className="principle-card" key={principle}>
+                {principle}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="content-section">
+          <div className="section-heading">
+            <span className="eyebrow">Audience map</span>
+            <h2>Eight addressable segments already identified in the repo.</h2>
+            <p>
+              Each segment needs different pacing, packaging, and depth even though they draw from the same
+              source archive.
+            </p>
+          </div>
+          <div className="audience-table">
+            {audienceSegments.map((segment) => (
+              <article className="audience-row" key={segment.id}>
+                <div>
+                  <h3>{segment.name}</h3>
+                  <p>{segment.promise}</p>
+                </div>
+                <div>
+                  <p className="audience-meta"><strong>Format:</strong> {segment.format}</p>
+                  <p className="audience-meta"><strong>Best for:</strong> {segment.bestFor.join(', ')}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="content-section alt-surface">
+          <div className="section-heading">
+            <span className="eyebrow">Interactive product stack</span>
+            <h2>Three layers beyond static reading.</h2>
+          </div>
+          <div className="stack-grid">
+            <article className="stack-card">
+              <h3>1. Content layer</h3>
+              <p>Structured story pages, summaries, images, and scripture-linked metadata.</p>
+            </article>
+            <article className="stack-card">
+              <h3>2. Ritual layer</h3>
+              <p>Quizzes, family prompts, challenge sequences, and festival-based programming.</p>
+            </article>
+            <article className="stack-card">
+              <h3>3. Conversational layer</h3>
+              <p>Guided Q&amp;A, AI-avatar narration, age-adaptive prompts, and contextual recommendations.</p>
+            </article>
+          </div>
+          <div className="interactive-grid">
+            {interactiveProducts.map((product) => (
+              <article className="interactive-card" key={product.title}>
+                <h3>{product.title}</h3>
+                <p>{product.description}</p>
+                <ul>
+                  {product.prompts.map((prompt) => (
+                    <li key={prompt}>{prompt}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="content-section">
+          <div className="section-heading">
+            <span className="eyebrow">Execution cadence</span>
+            <h2>A realistic validate → deepen → scale sequence.</h2>
+          </div>
+          <div className="timeline-grid">
+            {rolloutPlan.map((phase) => (
+              <article className="timeline-card" key={phase.phase}>
+                <h3>{phase.phase}</h3>
+                <p>{phase.focus}</p>
+                <ul>
+                  {phase.actions.map((action) => (
+                    <li key={action}>{action}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
     </div>
   );
 }
-
 
 export default About;

--- a/englishpurana/src/components/home.js
+++ b/englishpurana/src/components/home.js
@@ -1,58 +1,240 @@
-
-import Button from "react-bootstrap/Button";
-// import Text from 'react-text';
-import logo from '../logo.png';
-import Main from "./main.js"
-import { useHistory } from "react-router-dom";
+import { useMemo, useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Col from 'react-bootstrap/Col';
+import Navbar from 'react-bootstrap/Navbar';
+import Row from 'react-bootstrap/Row';
+import { useHistory } from 'react-router-dom';
 import '../App.css';
-import Navbar from "react-bootstrap/Navbar";
+import logo from '../logo.png';
+import {
+  audienceSegments,
+  interactiveProducts,
+  kpiFramework,
+  launchFranchises,
+  rolloutPlan,
+} from '../content_deliveryIdeas';
+
+const audienceGoals = [
+  {
+    id: 'discovery',
+    label: 'Maximize discovery',
+    matches: ['kids', 'global-seekers', 'diaspora'],
+    description: 'Prioritize formats that travel well on short-form and introductory channels.',
+  },
+  {
+    id: 'depth',
+    label: 'Build deeper learning',
+    matches: ['young-adults', 'diaspora', 'seniors'],
+    description: 'Emphasize richer context, commentary, and repeatable educational value.',
+  },
+  {
+    id: 'retention',
+    label: 'Create weekly habits',
+    matches: ['professionals', 'families', 'seniors'],
+    description: 'Lean into ritualized formats that people return to on a schedule.',
+  },
+];
 
 function Home() {
   const history = useHistory();
+  const [selectedGoal, setSelectedGoal] = useState(audienceGoals[0].id);
 
-  const goLogin = () => {
-    history.push('login');
-  }
+  const recommendedAudienceIds = useMemo(() => {
+    const activeGoal = audienceGoals.find((goal) => goal.id === selectedGoal);
+    return activeGoal ? activeGoal.matches : [];
+  }, [selectedGoal]);
+
+  const recommendedAudiences = audienceSegments.filter((segment) =>
+    recommendedAudienceIds.includes(segment.id)
+  );
+
   return (
-    <div className="App">
-    <Navbar bg="warning" variant="light">
-    <Navbar.Brand href="/" >
-    <img
-      alt=""
-      src={logo}
-      width="35"
-      height="35"
-      className="d-inline-block align-top"
-    />{' '}
-      Simple Puranas
-    </Navbar.Brand>
-    <Navbar.Toggle />
-  <Navbar.Collapse className="justify-content-end">
-  <Navbar.Brand type="button" className="btn btn-link" style={{color:"white"}}>
-  <a href="about" style={{color:"Brown"}}>About</a>
-  </Navbar.Brand>
-  <Navbar.Text>
-&nbsp;&nbsp;
-  </Navbar.Text>
-    <Navbar.Text>
-    <Button variant="outline-light" href="/login">Signin</Button>
-    </Navbar.Text>
-  </Navbar.Collapse>
-  </Navbar>
-    <header className="App-header">
-    <img src={logo} className="App-logo" alt="logo" />
-      <p className="mb-0 h1" style={{textDecoration:"underline", color:"yellow"}}>Simple Puranas</p>
-      <br/>
-      <p>Stories from ancient india.</p>
-      <p>Indian puranas are stories explaining the fundamentals and origins of Indian hindu religion.</p>
-      <p>Read and share stories about Indian gods, thier significance,</p>
-      <p>ways to worship them, and thier endeavours to enhance humanity.</p>
-      <p>Assimilate the teachings of the puranas to enhance your lives.</p>
-      <input type="button" className="btn btn-primary" value="Login" onClick={goLogin}></input>
-    </header>
+    <div className="App app-shell">
+      <Navbar bg="warning" variant="light" className="app-navbar">
+        <Navbar.Brand href="/" className="brand-lockup">
+          <img
+            alt="Simple Puranas logo"
+            src={logo}
+            width="35"
+            height="35"
+            className="d-inline-block align-top"
+          />{' '}
+          Simple Puranas
+        </Navbar.Brand>
+        <Navbar.Toggle />
+        <Navbar.Collapse className="justify-content-end">
+          <Navbar.Brand className="btn btn-link nav-link-button">
+            <a href="about" style={{ color: 'brown' }}>
+              Roadmap
+            </a>
+          </Navbar.Brand>
+          <Navbar.Text>
+            <Button variant="outline-light" href="/login">
+              Sign in
+            </Button>
+          </Navbar.Text>
+        </Navbar.Collapse>
+      </Navbar>
+
+      <main className="landing-page">
+        <section className="hero-panel">
+          <div className="hero-copy">
+            <span className="eyebrow">Modern delivery ideas for timeless stories</span>
+            <h1>Simple Puranas can become more than a reading archive.</h1>
+            <p className="hero-lead">
+              This product direction turns the repository’s idea list into an actionable content system:
+              audience-specific storytelling, launchable franchises, interactive rituals, and a measurable
+              90-day rollout.
+            </p>
+            <div className="hero-actions">
+              <Button variant="primary" onClick={() => history.push('/about')}>
+                Explore the roadmap
+              </Button>
+              <Button variant="outline-light" onClick={() => history.push('/login')}>
+                Continue to reader app
+              </Button>
+            </div>
+          </div>
+
+          <div className="hero-highlight-card">
+            <p className="mini-label">Recommended launch wedge</p>
+            <h2>Diaspora teens + dilemma-led short video</h2>
+            <p>
+              Start narrow: teach modern decisions through emotionally relevant Purana moments, then deepen
+              into long-form explainers, Q&amp;A, and interactive products.
+            </p>
+            <ul>
+              <li>Short-form discovery with “Pick the Dharma” debates.</li>
+              <li>Weekly long-form for context, symbolism, and cultural identity.</li>
+              <li>Interactive follow-up via Ask the Rishi and quiz loops.</li>
+            </ul>
+          </div>
+        </section>
+
+        <section className="content-section">
+          <div className="section-heading">
+            <span className="eyebrow">Audience studio</span>
+            <h2>Choose the growth goal and see the strongest audience segments.</h2>
+            <p>
+              The repo’s ideas become more useful when grouped by strategy: discovery, depth, or retention.
+            </p>
+          </div>
+
+          <div className="goal-tabs">
+            {audienceGoals.map((goal) => (
+              <button
+                key={goal.id}
+                type="button"
+                className={selectedGoal === goal.id ? 'goal-tab active' : 'goal-tab'}
+                onClick={() => setSelectedGoal(goal.id)}
+              >
+                <strong>{goal.label}</strong>
+                <span>{goal.description}</span>
+              </button>
+            ))}
+          </div>
+
+          <Row>
+            {recommendedAudiences.map((segment) => (
+              <Col md={4} className="mb-4" key={segment.id}>
+                <Card className="idea-card h-100">
+                  <Card.Body>
+                    <span className="mini-label">{segment.flagship}</span>
+                    <Card.Title>{segment.name}</Card.Title>
+                    <Card.Subtitle className="mb-2 text-muted">{segment.format}</Card.Subtitle>
+                    <Card.Text>
+                      <strong>{segment.hook}</strong>
+                    </Card.Text>
+                    <Card.Text>{segment.promise}</Card.Text>
+                    <div className="pill-row">
+                      {segment.channels.map((channel) => (
+                        <span className="idea-pill" key={channel}>
+                          {channel}
+                        </span>
+                      ))}
+                    </div>
+                  </Card.Body>
+                </Card>
+              </Col>
+            ))}
+          </Row>
+        </section>
+
+        <section className="content-section alt-surface">
+          <div className="section-heading">
+            <span className="eyebrow">Launchable franchises</span>
+            <h2>Five repeatable show formats that can organize the whole product.</h2>
+          </div>
+          <div className="franchise-grid">
+            {launchFranchises.map((franchise) => (
+              <article className="franchise-card" key={franchise.title}>
+                <p className="mini-label">{franchise.format}</p>
+                <h3>{franchise.title}</h3>
+                <p>{franchise.outcome}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="content-section">
+          <div className="section-heading">
+            <span className="eyebrow">Interactive extensions</span>
+            <h2>Use the archive as a foundation for products, not just pages.</h2>
+          </div>
+          <div className="interactive-grid">
+            {interactiveProducts.map((product) => (
+              <article className="interactive-card" key={product.title}>
+                <h3>{product.title}</h3>
+                <p>{product.description}</p>
+                <ul>
+                  {product.prompts.map((prompt) => (
+                    <li key={prompt}>{prompt}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="content-section alt-surface">
+          <div className="section-heading">
+            <span className="eyebrow">90-day execution plan</span>
+            <h2>Turn inspiration into a staged rollout.</h2>
+          </div>
+          <div className="timeline-grid">
+            {rolloutPlan.map((phase) => (
+              <article className="timeline-card" key={phase.phase}>
+                <h3>{phase.phase}</h3>
+                <p>{phase.focus}</p>
+                <ul>
+                  {phase.actions.map((action) => (
+                    <li key={action}>{action}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="content-section">
+          <div className="section-heading">
+            <span className="eyebrow">Measurement</span>
+            <h2>Track whether Simple Puranas is growing attention, trust, and repeat usage.</h2>
+          </div>
+          <div className="kpi-grid">
+            {kpiFramework.map((kpi) => (
+              <article className="kpi-card" key={kpi.label}>
+                <h3>{kpi.label}</h3>
+                <p className="metric-line">{kpi.metric}</p>
+                <p>{kpi.note}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
     </div>
   );
 }
-
 
 export default Home;

--- a/englishpurana/src/content_deliveryIdeas.js
+++ b/englishpurana/src/content_deliveryIdeas.js
@@ -1,0 +1,203 @@
+export const audienceSegments = [
+  {
+    id: 'kids',
+    name: 'Kids (6–12)',
+    format: '45–90 second mythology adventure shorts',
+    hook: 'One hero, one problem, one moral.',
+    promise: 'Turn Purana lessons into chibi-style, choice-driven stories that are easy to replay with family.',
+    channels: ['YouTube Shorts', 'Instagram Reels', 'Choice polls'],
+    bestFor: ['Discovery', 'Family sharing'],
+    flagship: 'Dharma in 60 Seconds',
+  },
+  {
+    id: 'teens',
+    name: 'Teens (13–19)',
+    format: '3–6 minute story explainers and debate clips',
+    hook: 'Ancient stories for modern decisions.',
+    promise: 'Connect dharma dilemmas to friendship, school pressure, anxiety, and social identity.',
+    channels: ['Short explainers', 'Live votes', 'Debate clips'],
+    bestFor: ['Engagement', 'Conversation'],
+    flagship: 'Pick the Dharma',
+  },
+  {
+    id: 'young-adults',
+    name: 'College + Early Career (18–30)',
+    format: '8–15 minute episodes and podcast snippets',
+    hook: 'Productivity, conviction, and emotional regulation.',
+    promise: 'Translate Purana wisdom into leadership, discipline, purpose, and resilience frameworks.',
+    channels: ['YouTube', 'Podcast clips', 'LinkedIn carousels'],
+    bestFor: ['Depth', 'Professional discovery'],
+    flagship: 'Purana for Real Life',
+  },
+  {
+    id: 'professionals',
+    name: 'Working Professionals (25–45)',
+    format: '10-minute commute-first audio reflections',
+    hook: 'Story, takeaway, and action prompt in one listen.',
+    promise: 'Create a calm daily ritual that fits into commutes and lunch breaks.',
+    channels: ['Spotify', 'Apple Podcasts', 'Email course'],
+    bestFor: ['Retention', 'Daily habit'],
+    flagship: '7-Day Dharma Challenge',
+  },
+  {
+    id: 'families',
+    name: 'Parents + Families',
+    format: 'Weekend co-watching ritual content',
+    hook: 'Story + quiz + craft + family discussion.',
+    promise: 'Turn passive viewing into a repeatable family value practice.',
+    channels: ['Weekend episodes', 'Printable cards', 'Family quizzes'],
+    bestFor: ['Co-viewing', 'Habit building'],
+    flagship: 'Family Purana Night',
+  },
+  {
+    id: 'seniors',
+    name: 'Seniors (50+)',
+    format: 'Slow-paced devotional narration with large text',
+    hook: 'Respectful, high-clarity listening and reading.',
+    promise: 'Support devotional immersion through Shravana-style playback and readable typography.',
+    channels: ['Large-text video', 'Bilingual subtitles', 'Autoplay playlists'],
+    bestFor: ['Accessibility', 'Longer sessions'],
+    flagship: 'Shravana Mode',
+  },
+  {
+    id: 'diaspora',
+    name: 'Diaspora Audiences',
+    format: 'Mythology-in-context mini-documentaries',
+    hook: 'A cultural identity bridge for second-generation viewers.',
+    promise: 'Explain symbolism, geography, and festivals without assuming prior background knowledge.',
+    channels: ['Mini-docs', 'Virtual satsang', 'Q&A sessions'],
+    bestFor: ['Identity building', 'Community'],
+    flagship: 'Mythology in Context',
+  },
+  {
+    id: 'global-seekers',
+    name: 'Global Spiritual Seekers',
+    format: 'Comparative mythology explainers',
+    hook: 'Universal themes first, tradition-specific depth second.',
+    promise: 'Make duty, ego, compassion, and transformation legible to newcomers.',
+    channels: ['Essay videos', 'Comparative explainers', 'Prompt cards'],
+    bestFor: ['Top-of-funnel education', 'Cross-cultural discovery'],
+    flagship: 'Ancient Indian Stories, Modern Human Questions',
+  },
+];
+
+export const launchFranchises = [
+  {
+    title: 'Dharma in 60 Seconds',
+    format: 'Daily shorts',
+    outcome: 'High-frequency discovery with one moral per story.',
+  },
+  {
+    title: 'Purana for Real Life',
+    format: 'Weekly long-form',
+    outcome: 'Build depth through practical applications for modern work and relationships.',
+  },
+  {
+    title: 'Ask the Rishi',
+    format: 'Interactive AI/avatar Q&A',
+    outcome: 'Create a conversational bridge between archive content and life questions.',
+  },
+  {
+    title: 'Family Purana Night',
+    format: 'Weekend ritual content',
+    outcome: 'Anchor repeatable co-viewing, quizzes, and discussion prompts.',
+  },
+  {
+    title: 'Quest of the Sages',
+    format: 'Gamified learning journey',
+    outcome: 'Turn reading into streaks, scenario questions, and unlockable rewards.',
+  },
+];
+
+export const rolloutPlan = [
+  {
+    phase: 'Days 1–30 · Validate',
+    focus: 'Test discovery hooks and narrator styles.',
+    actions: [
+      'Publish 20 shorts across courage, ego, devotion, and duty.',
+      'Test human voice, AI avatar, and duet narration formats.',
+      'Capture emails with a “7 stories for modern life” lead magnet.',
+    ],
+  },
+  {
+    phase: 'Days 31–60 · Deepen',
+    focus: 'Introduce longer-form trust builders.',
+    actions: [
+      'Launch a weekly 10-minute long-form episode.',
+      'Add quizzes, polls, and audience question collection loops.',
+      'Prototype either the chatbot or gamified quiz MVP.',
+    ],
+  },
+  {
+    phase: 'Days 61–90 · Scale',
+    focus: 'Package the strongest signal into a flagship product.',
+    actions: [
+      'Launch one interactive product such as Ask the Rishi or a mini-game.',
+      'Start partnerships with schools, temples, diaspora communities, and podcast guests.',
+      'Formalize repeatable production SOPs and a contributor network.',
+    ],
+  },
+];
+
+export const kpiFramework = [
+  {
+    label: 'Discovery',
+    metric: 'Watch-through rate, shares, saves',
+    note: 'Measures whether the hook and packaging travel.',
+  },
+  {
+    label: 'Connection',
+    metric: 'Comments per 1,000 views, returning viewers',
+    note: 'Shows emotional resonance and audience identity fit.',
+  },
+  {
+    label: 'Depth',
+    metric: 'Long-form completion rate, listen duration',
+    note: 'Signals whether viewers trust the deeper teaching layer.',
+  },
+  {
+    label: 'Conversion',
+    metric: 'Email signups, app installs, community joins',
+    note: 'Tracks movement from casual attention into owned audience.',
+  },
+  {
+    label: 'Retention',
+    metric: '7-day and 30-day return rate',
+    note: 'Validates that rituals, streaks, and prompts are working.',
+  },
+];
+
+export const interactiveProducts = [
+  {
+    title: 'Ask the Rishi',
+    description: 'An AI-avatar guide that adapts tone and depth for kids, families, and reflective adults.',
+    prompts: [
+      'Tell me a story about handling anger.',
+      'Give me a bedtime Purana for my 8-year-old.',
+      'What does Prahlada teach about conviction under pressure?',
+    ],
+  },
+  {
+    title: 'Quest of the Sages',
+    description: 'A gamified reading path with scenario questions, Dharma points, and unlockable story archives.',
+    prompts: ['Story quests by Purana', 'Character cards', 'Moral alignment meter'],
+  },
+  {
+    title: 'Family Value Cards',
+    description: 'Printable cards that pair one story, one reflection, and one activity for weekend rituals.',
+    prompts: ['Story recap', 'Craft idea', 'Family discussion question'],
+  },
+  {
+    title: 'Festival Content Calendar',
+    description: 'A seasonal programming layer that maps stories and themes to major Hindu festivals.',
+    prompts: ['Navratri themes', 'Janmashtami family stories', 'Maha Shivaratri reflections'],
+  },
+];
+
+export const ideaPrinciples = [
+  'Start with one audience and one flagship format before expanding.',
+  'Package ancient wisdom in modern, accessible, age-appropriate language.',
+  'Create interaction loops through quizzes, polls, streaks, and Q&A.',
+  'Make the archive usable for readers, listeners, families, and educators.',
+  'Track discovery, depth, conversion, and retention—not just page views.',
+];


### PR DESCRIPTION
### Motivation
- Convert the repo's delivery ideas into a concrete product entrypoint so contributors and stakeholders can see a clear roadmap and launch wedge. 
- Surface audience segmentation, launch franchises, interactive product concepts and a 90-day rollout inside the app to make strategy decisions actionable. 
- Centralize content primitives that will power future features (chatbot, gamified reading, audio-first formats) so UI and product planning share a single source of truth.

### Description
- Replaced the generic homepage with a strategy-led landing experience and audience-goal selector in `englishpurana/src/components/home.js`, driven by structured idea data. 
- Introduced a structured content module `englishpurana/src/content_deliveryIdeas.js` that exports `audienceSegments`, `launchFranchises`, `rolloutPlan`, `kpiFramework`, `interactiveProducts`, and product `ideaPrinciples`. 
- Reworked the `/about` page into a roadmap/strategy view that explains operating principles, audience mapping, product layers, and the validate→deepen→scale cadence in `englishpurana/src/components/about.js`. 
- Styling and small app-shell cleanup in `englishpurana/src/App.css` and `englishpurana/src/App.js` to support the card-based layout, and replaced the default CRA test with a regression test in `englishpurana/src/App.test.js` that asserts the new homepage sections render.

### Testing
- Ran the unit test suite with `CI=true npm test -- --watchAll=false` which passed (`src/App.test.js` verifies key landing page text). 
- Attempted a production build with `npm run build`, which failed in this environment due to an upstream dependency resolution issue where `postcss-safe-parser` imports a `postcss` subpath that is not exported under Node.js 20; this is unrelated to the functional changes in the new pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7bfb960883289ce2c4411f380072)